### PR TITLE
Add linking with lssp if MinGW is used

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,10 @@ target_link_libraries(Suvorov
     sc2api sc2lib sc2utils sc2protocol civetweb libprotobuf
 )
 
+if (MINGW)
+    target_link_libraries(Suvorov ssp)
+endif()
+
 if (APPLE)
     target_link_libraries(Suvorov "-framework Carbon")
 endif ()


### PR DESCRIPTION
This fix makes it possible to compile with clang (using Mingw). Mingw + gcc compiles but crashes with segfault though.