### PR TITLE
Fix Issue #45 "Reapers don't require tech lab anymore"

### DIFF
--- a/src/blueprints/Blueprint.cpp
+++ b/src/blueprints/Blueprint.cpp
@@ -99,11 +99,11 @@ std::shared_ptr<Blueprint> Blueprint::Plot(sc2::ABILITY_ID ability_) {
                 sc2::UNIT_TYPEID::TERRAN_FACTORYTECHLAB);
 
         case sc2::ABILITY_ID::TRAIN_MARINE:
+        case sc2::ABILITY_ID::TRAIN_REAPER:
             return std::make_shared<Unit>(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
 
         case sc2::ABILITY_ID::TRAIN_GHOST:
         case sc2::ABILITY_ID::TRAIN_MARAUDER:
-        case sc2::ABILITY_ID::TRAIN_REAPER:
             return std::make_shared<HighTechUnit>(
                 sc2::UNIT_TYPEID::TERRAN_BARRACKS,
                 sc2::UNIT_TYPEID::TERRAN_BARRACKSTECHLAB);

--- a/src/core/API.cpp
+++ b/src/core/API.cpp
@@ -209,7 +209,6 @@ sc2::UnitTypeData Observer::GetUnitTypeData(sc2::UNIT_TYPEID id_) const {
             break;
 
         case sc2::UNIT_TYPEID::TERRAN_MARAUDER:
-        case sc2::UNIT_TYPEID::TERRAN_REAPER:
             data.tech_requirement = sc2::UNIT_TYPEID::TERRAN_BARRACKSTECHLAB;
             break;
 


### PR DESCRIPTION
Removes REAPER from BARRACKSTECHLAB case in API.cpp's tech_requirement workaround.
Tested building Reapers without a BarrackTechLab and it works now.