### PR TITLE
Fix Issue #12: "Better buildings placement" by checking Add-On space

### DIFF
--- a/src/blueprints/Building.cpp
+++ b/src/blueprints/Building.cpp
@@ -6,6 +6,16 @@
 #include "Hub.h"
 #include "core/API.h"
 
+bool HasAddonSpace(Order* order_, const sc2::Point2D& point) {
+    if (order_->ability_id != sc2::ABILITY_ID::BUILD_BARRACKS &&
+        order_->ability_id != sc2::ABILITY_ID::BUILD_FACTORY &&
+        order_->ability_id != sc2::ABILITY_ID::BUILD_STARPORT)
+        return true;
+
+    sc2::Point2D addon_pos(point.x + 2.5f, point.y - 0.5f);
+    return gAPI->query().CanBePlaced(sc2::ABILITY_ID::BUILD_SUPPLYDEPOT, addon_pos);
+}
+
 bool Building::Build(Order* order_) {
     // Find place to build the structure
     sc2::Point3D base = gAPI->observer().StartingLocation();
@@ -18,7 +28,8 @@ bool Building::Build(Order* order_) {
 
         if (++attempt > 150)
             return false;
-    } while (!gAPI->query().CanBePlaced(*order_, point));
+    } while (!(gAPI->query().CanBePlaced(*order_, point) &&
+               HasAddonSpace(order_, point)));
 
     return gHub->AssignBuildTask(order_, point);
 }


### PR DESCRIPTION
This will build Barracks, Factory, Starport with space for an addon, but won't prevent new buildings from blocking the addon space.