### PR TITLE
Fix Issue #35 "Improve mineral saturation"

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -145,6 +145,16 @@ void Dispatcher::OnUpgradeCompleted(sc2::UpgradeID id_) {
         i->OnUpgradeCompleted(id_);
 }
 
+void Dispatcher::OnUnitEnterVision(const sc2::Unit* unit_) {
+//    gHistory.info() << sc2::UnitTypeToName(unit_->unit_type) <<
+//        "(" << unit_->tag << ")  entered vision" << std::endl;
+
+    gHub->OnUnitEnterVision(*unit_);
+
+    for (const auto& i : m_plugins)
+        i->OnUnitEnterVision(unit_, m_builder.get());
+}
+
 void Dispatcher::OnError(const std::vector<sc2::ClientError>& client_errors,
         const std::vector<std::string>& protocol_errors) {
     for (const auto i : client_errors) {

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -32,6 +32,8 @@ struct Dispatcher: sc2::Agent {
 
     void OnUpgradeCompleted(sc2::UpgradeID id_) final;
 
+    void OnUnitEnterVision(const sc2::Unit* unit_) final;
+
     void OnError(const std::vector<sc2::ClientError>& client_errors,
         const std::vector<std::string>& protocol_errors = {}) final;
 

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -123,6 +123,8 @@ struct Hub {
 
     void OnUnitIdle(const sc2::Unit& unit_);
 
+    void OnUnitEnterVision(const sc2::Unit& unit_);
+
     bool IsOccupied(const sc2::Unit& unit_) const;
 
     bool IsTargetOccupied(const sc2::UnitOrder& order_) const;
@@ -139,7 +141,7 @@ struct Hub {
 
     bool AssignRefineryConstruction(Order* order_, const sc2::Unit* geyser_);
 
-    bool AssignBuildTask(Order* order_, const sc2::Point2D& point_);
+    sc2::Tag AssignBuildTask(Order* order_, const sc2::Point2D& point_);
 
     void AssignVespeneHarvester(const sc2::Unit& refinery_);
 
@@ -149,9 +151,19 @@ struct Hub {
 
     const Expansions& GetExpansions() const;
 
-    const sc2::Point3D* GetNextExpansion();
+    Expansion* GetNextExpansion();
+
+    const Expansion* GetBestMiningExpansionNear(const sc2::Unit* unit_) const;
 
  private:
+    Expansion* GetExpansionOfTownhall(const sc2::Unit& unit_);
+
+    void CaptureExpansion(const sc2::Unit& unit_);
+
+    void EnemyOwnsExpansion(const sc2::Unit& unit_);
+
+    void RemoveExpansionOwner(const sc2::Unit& unit_);
+
     sc2::Race m_current_race;
     Expansions m_expansions;
     sc2::UNIT_TYPEID m_current_supply_type;

--- a/src/blueprints/TownHall.cpp
+++ b/src/blueprints/TownHall.cpp
@@ -7,9 +7,15 @@
 #include "core/API.h"
 
 bool TownHall::Build(Order* order_) {
-    const sc2::Point3D* town_hall_location = gHub->GetNextExpansion();
-    if (!town_hall_location)
+    Expansion* next_expand = gHub->GetNextExpansion();
+    if (!next_expand)
         return false;
 
-    return gHub->AssignBuildTask(order_, *town_hall_location);
+    sc2::Tag builder = gHub->AssignBuildTask(order_, next_expand->town_hall_location);
+    if (!builder)
+        return false;
+
+    next_expand->worker_tag = builder;
+
+    return true;
 }

--- a/src/core/Helpers.cpp
+++ b/src/core/Helpers.cpp
@@ -12,14 +12,14 @@ IsUnit::IsUnit(sc2::UNIT_TYPEID type_): m_type(type_) {
 }
 
 bool IsUnit::operator()(const sc2::Unit& unit_) const {
-    return unit_.unit_type == m_type && unit_.build_progress >= 1.0f;
+    return unit_.unit_type == m_type && unit_.build_progress >= BUILD_FINISHED;
 }
 
 OneOfUnits::OneOfUnits(const std::set<sc2::UNIT_TYPEID>& types_): m_types(types_) {
 }
 
 bool OneOfUnits::operator()(const sc2::Unit& unit_) const {
-    return unit_.build_progress == 1.0f &&
+    return unit_.build_progress == BUILD_FINISHED &&
         m_types.find(unit_.unit_type) != m_types.end();
 }
 
@@ -103,7 +103,7 @@ bool IsFreeGeyser::operator()(const sc2::Unit& unit_) const {
 }
 
 bool IsRefinery::operator()(const sc2::Unit& unit_) const {
-    if (unit_.build_progress != 1.0f)
+    if (unit_.build_progress != BUILD_FINISHED)
         return false;
 
     return unit_.unit_type == sc2::UNIT_TYPEID::PROTOSS_ASSIMILATOR ||
@@ -145,7 +145,7 @@ bool IsGasWorker::operator()(const sc2::Unit& unit_) const {
 
 bool IsIdleTownHall::operator()(const sc2::Unit& unit_) const {
     return sc2::IsTownHall()(unit_) &&
-        unit_.orders.empty() && unit_.build_progress == 1.0f;
+        unit_.orders.empty() && unit_.build_progress == BUILD_FINISHED;
 }
 
 bool IsCommandCenter::operator()(const sc2::Unit& unit_) const {

--- a/src/core/Helpers.h
+++ b/src/core/Helpers.h
@@ -11,6 +11,8 @@
 
 #include <set>
 
+const float BUILD_FINISHED = 1.0f;
+
 struct IsUnit {
     explicit IsUnit(sc2::UNIT_TYPEID type_);
 

--- a/src/core/Map.cpp
+++ b/src/core/Map.cpp
@@ -94,7 +94,23 @@ sc2::Point3D Cluster::Center() const {
 }  // namespace
 
 Expansion::Expansion(const sc2::Point3D& town_hall_location_):
-    town_hall_location(town_hall_location_), owner(Owner::NEUTRAL) {
+    town_hall_location(town_hall_location_), owner(Owner::NEUTRAL),
+    town_hall_tag(sc2::NullTag), worker_tag(sc2::NullTag) {
+}
+
+void Expansion::SetOwner(const sc2::Unit& unit_, Owner owner_) {
+    town_hall_tag = unit_.tag;
+    owner = owner_;
+
+    // Terran worker_tag should remain as it constructs TownHall
+    if (gAPI->observer().GetCurrentRace() != sc2::Race::Terran)
+        worker_tag = sc2::NullTag;
+}
+
+void Expansion::RemoveOwner() {
+    owner = Owner::NEUTRAL;
+    town_hall_tag = sc2::NullTag;
+    worker_tag = sc2::NullTag;
 }
 
 Expansions CalculateExpansionLocations() {
@@ -151,6 +167,9 @@ Expansions CalculateExpansionLocations() {
 
         start_index += query_size[i.id];
     }
+
+    // Include start location. TownHall tag will be added during its OnCreated event.
+    expansions.emplace_back(gAPI->observer().StartingLocation());
 
     return expansions;
 }

--- a/src/core/Map.h
+++ b/src/core/Map.h
@@ -10,17 +10,24 @@
 #include <vector>
 
 enum Owner {
-    NEUTRAL = 0,
-    CONTESTED = 1,
-    ENEMY = 2,
-    SELF = 3,
+    NEUTRAL = 0,  // No Townhall at expansion, no workers enroute
+    CONTESTED = 1,  // No Townhall, Enemy may be present, Self Worker enroute
+    ENEMY = 2,  // Enemy TownHall at expansion
+    SELF = 3,  // Self TownHall at expansion, possibly under construction
 };
 
 struct Expansion {
     explicit Expansion(const sc2::Point3D& town_hall_location_);
 
+    void SetOwner(const sc2::Unit& unit_, Owner owner_);
+
+    void RemoveOwner();
+
     sc2::Point3D town_hall_location;
     Owner owner;
+    sc2::Tag town_hall_tag;  // valid for Owner::SELF or ENEMY
+    sc2::Tag worker_tag;  // valid for Owner::CONTESTED or SELF
+    // NOTE (impulsecloud): check for dead builder, send new
 };
 
 typedef std::vector<Expansion> Expansions;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -30,6 +30,9 @@ struct Plugin {
     virtual void OnUpgradeCompleted(sc2::UpgradeID) {
     }
 
+    virtual void OnUnitEnterVision(const sc2::Unit*, Builder*) {
+    }
+
     virtual void OnGameEnd() {
     }
 };

--- a/src/plugins/QuarterMaster.cpp
+++ b/src/plugins/QuarterMaster.cpp
@@ -6,6 +6,7 @@
 #include "Hub.h"
 #include "QuarterMaster.h"
 #include "core/API.h"
+#include "core/Helpers.h"
 
 #include <numeric>
 
@@ -24,7 +25,7 @@ float CalcSupplies::operator()(float sum, const sc2::Unit* unit_) const {
         case sc2::UNIT_TYPEID::TERRAN_ORBITALCOMMAND:
         case sc2::UNIT_TYPEID::TERRAN_ORBITALCOMMANDFLYING:
         case sc2::UNIT_TYPEID::TERRAN_PLANETARYFORTRESS:
-            if (unit_->build_progress < 1.0f)
+            if (unit_->build_progress < BUILD_FINISHED)
                 return sum;
             return sum + 15.0f;
 
@@ -58,7 +59,7 @@ struct CalcConsumptionRate {
 };
 
 float CalcConsumptionRate::operator()(float sum, const sc2::Unit* unit_) const {
-    if (unit_->build_progress != 1.0f)
+    if (unit_->build_progress != BUILD_FINISHED)
         return sum;
 
     switch (unit_->unit_type.ToType()) {

--- a/src/plugins/RepairMan.cpp
+++ b/src/plugins/RepairMan.cpp
@@ -19,7 +19,7 @@ void RepairMan::OnUnitDestroyed(const sc2::Unit* unit_, Builder* builder_) {
 
     // NOTE (alkurbatov): If build_progress < 1.0f a unit might be
     // destroyed by the CancelConstruction command.
-    if (unit_->build_progress < 1.0f)
+    if (unit_->build_progress < BUILD_FINISHED)
         return;
 
     switch (unit_->unit_type.ToType()) {

--- a/src/strategies/terran/MarinePush.cpp
+++ b/src/strategies/terran/MarinePush.cpp
@@ -4,6 +4,7 @@
 
 #include "Historican.h"
 #include "MarinePush.h"
+#include "Hub.h"
 
 namespace {
 Historican gHistory("strategy.marine_push");
@@ -15,19 +16,20 @@ MarinePush::MarinePush(): Strategy(16.0f) {
 void MarinePush::OnGameStart(Builder* builder_) {
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_SUPPLYDEPOT);
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
-    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_COMMANDCENTER);
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_REFINERY);
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_ORBITALCOMMAND);
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
-    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKSTECHLAB);
+    builder_->ScheduleOptionalOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKSTECHLAB);
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
     builder_->ScheduleObligatoryOrder(sc2::UPGRADE_ID::SHIELDWALL);
     builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
-    builder_->ScheduleOptionalOrder(sc2::UPGRADE_ID::STIMPACK);
-    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKSREACTOR);
-    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKSREACTOR);
-    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKSREACTOR);
-    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKSREACTOR);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_COMMANDCENTER);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
+    builder_->ScheduleObligatoryOrder(sc2::UNIT_TYPEID::TERRAN_BARRACKS);
 }
 
 void MarinePush::OnUnitIdle(const sc2::Unit* unit_, Builder* builder_) {


### PR DESCRIPTION
This will send new/idle workers to a non-saturated townhall. Townhalls will build an extra worker over Ideal and it will go to a new non-saturated townhall upon creation, so each townhall will continually build workers if there are any townhalls that are not yet saturated (until 80 total). After constructing a building, workers will go to an unsaturated townhall instead of the closest/starting one.