### PR TITLE
Feature #27: Repair Terran buildings

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -125,6 +125,11 @@ void Dispatcher::OnUnitIdle(const sc2::Unit* unit_) {
         i->OnUnitIdle(unit_, m_builder.get());
 }
 
+void Dispatcher::OnUnitDamaged(const sc2::Unit* unit_, float health_, float shields_) {
+    for (const auto& i : m_plugins)
+        i->OnUnitDamaged(unit_, health_, shields_, m_builder.get());
+}
+
 void Dispatcher::OnUnitDestroyed(const sc2::Unit* unit_) {
     if (unit_->alliance != sc2::Unit::Alliance::Self)
         return;
@@ -146,9 +151,6 @@ void Dispatcher::OnUpgradeCompleted(sc2::UpgradeID id_) {
 }
 
 void Dispatcher::OnUnitEnterVision(const sc2::Unit* unit_) {
-//    gHistory.info() << sc2::UnitTypeToName(unit_->unit_type) <<
-//        "(" << unit_->tag << ")  entered vision" << std::endl;
-
     gHub->OnUnitEnterVision(*unit_);
 
     for (const auto& i : m_plugins)

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -28,6 +28,8 @@ struct Dispatcher: sc2::Agent {
 
     void OnUnitIdle(const sc2::Unit* unit_) final;
 
+    void OnUnitDamaged(const sc2::Unit* unit_, float health_, float shields_) final;
+
     void OnUnitDestroyed(const sc2::Unit* unit_) final;
 
     void OnUpgradeCompleted(sc2::UpgradeID id_) final;

--- a/src/core/API.cpp
+++ b/src/core/API.cpp
@@ -33,9 +33,17 @@ void Action::Attack(const sc2::Units& units_, const sc2::Point2D& point_) {
     m_action->UnitCommand(units_, sc2::ABILITY_ID::ATTACK_ATTACK, point_);
 }
 
+void Action::Cast(const sc2::Unit& assignee_, sc2::ABILITY_ID ability_) {
+    m_action->UnitCommand(&assignee_, convert::ToAbilityID(ability_));
+}
+
 void Action::Cast(const sc2::Unit& assignee_, sc2::ABILITY_ID ability_,
-    const sc2::Unit& target_) {
-    m_action->UnitCommand(&assignee_, convert::ToAbilityID(ability_), &target_);
+    const sc2::Unit& target_, bool queued) {
+    m_action->UnitCommand(&assignee_, convert::ToAbilityID(ability_), &target_, queued);
+}
+
+void Action::ToggleAutocast(sc2::Tag tag_, sc2::AbilityID ability_) {
+    m_action->ToggleAutocast(tag_, ability_);
 }
 
 void Action::Cancel(const sc2::Unit& assignee_) {

--- a/src/core/API.h
+++ b/src/core/API.h
@@ -28,8 +28,12 @@ struct Action {
 
     void Attack(const sc2::Units& units_, const sc2::Point2D& point_);
 
+    void Cast(const sc2::Unit& assignee_, sc2::ABILITY_ID ability_);
+
     void Cast(const sc2::Unit& assignee_, sc2::ABILITY_ID ability_,
-        const sc2::Unit& target_);
+        const sc2::Unit& target_, bool queued = false);
+
+    void ToggleAutocast(sc2::Tag tag_, sc2::AbilityID ability_);
 
     void Cancel(const sc2::Unit& assignee_);
 

--- a/src/core/Helpers.cpp
+++ b/src/core/Helpers.cpp
@@ -143,6 +143,17 @@ bool IsGasWorker::operator()(const sc2::Unit& unit_) const {
     return false;
 }
 
+bool IsRepairer::operator()(const sc2::Unit& unit_) const {
+    if (!sc2::IsWorker()(unit_))
+        return false;
+
+    if (unit_.orders.empty())
+        return false;
+
+    return unit_.orders.front().ability_id == sc2::ABILITY_ID::EFFECT_REPAIR ||
+        unit_.orders.front().ability_id == sc2::ABILITY_ID::EFFECT_REPAIR_SCV;
+}
+
 bool IsIdleTownHall::operator()(const sc2::Unit& unit_) const {
     return sc2::IsTownHall()(unit_) &&
         unit_.orders.empty() && unit_.build_progress == BUILD_FINISHED;

--- a/src/core/Helpers.h
+++ b/src/core/Helpers.h
@@ -61,6 +61,10 @@ struct IsGasWorker {
     bool operator()(const sc2::Unit& unit_) const;
 };
 
+struct IsRepairer {
+    bool operator()(const sc2::Unit& unit_) const;
+};
+
 struct IsIdleTownHall {
     bool operator()(const sc2::Unit& unit_) const;
 };

--- a/src/objects/Worker.cpp
+++ b/src/objects/Worker.cpp
@@ -27,3 +27,13 @@ void Worker::GatherVespene(const sc2::Unit& target_) {
     gAPI->action().Cast(ToUnit(), sc2::ABILITY_ID::SMART, target_);
     m_job = Job::GATHERING_VESPENE;
 }
+
+void Worker::Repair(const sc2::Unit& target_) {
+    // NOTE (impulsecloud): STOP first, then queue REPAIR to avoid bug
+    // when Minerals drop to 0 unexpectedly, REPAIR commands fail & keep GATHERING
+    // this bypasses OnIdle and leaves worker in BUSY list otherwise
+    gAPI->action().Cast(ToUnit(), sc2::ABILITY_ID::STOP_STOP);
+    gAPI->action().Cast(ToUnit(), sc2::ABILITY_ID::EFFECT_REPAIR, target_, true);
+    gAPI->action().ToggleAutocast(Tag(), sc2::ABILITY_ID::EFFECT_REPAIR_SCV);
+    m_job = Job::REPAIRING;
+}

--- a/src/objects/Worker.h
+++ b/src/objects/Worker.h
@@ -12,6 +12,7 @@ enum Job {
     GATHERING_VESPENE = 1,
     BUILDING = 2,
     BUILDING_REFINERY = 3,
+    REPAIRING = 4,
 };
 
 struct Worker: GameObject {
@@ -22,6 +23,8 @@ struct Worker: GameObject {
     void Build(Order* order_, const sc2::Point2D& point_);
 
     void GatherVespene(const sc2::Unit& target_);
+
+    void Repair(const sc2::Unit& target_);
 
  private:
     Job m_job;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -21,6 +21,9 @@ struct Plugin {
     virtual void OnUnitCreated(const sc2::Unit*, Builder*) {
     }
 
+    virtual void OnUnitDamaged(const sc2::Unit*, float, float, Builder*) {
+    }
+
     virtual void OnUnitDestroyed(const sc2::Unit*, Builder*) {
     }
 

--- a/src/plugins/RepairMan.h
+++ b/src/plugins/RepairMan.h
@@ -7,8 +7,17 @@
 #include "Builder.h"
 #include "Plugin.h"
 
+#include <list>
+
 struct RepairMan : Plugin {
     void OnStep(Builder* builder_) final;
 
+    void OnUnitDamaged(const sc2::Unit* unit_, float health_, float shields_, Builder*) final;
+
     void OnUnitDestroyed(const sc2::Unit* unit_, Builder* builder_) final;
+
+ private:
+    void AssignRepairTask(const sc2::Unit& damaged_);
+
+    std::list<const sc2::Unit*> m_damaged_buildings;
 };


### PR DESCRIPTION
When a building is first damaged, sends one repairer.
If no current repairers, sends one repairer to first still-damaged building.