### PR TITLE
fix: Fix gas saturation, #34

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -27,7 +27,8 @@ namespace {
 Historican gHistory("dispatcher");
 }  // namespace
 
-Dispatcher::Dispatcher(const std::string& opponent_id_): m_builder(new Builder()) {
+Dispatcher::Dispatcher(const std::string& opponent_id_): m_builder(new Builder()),
+    m_steps(0) {
     gAPI.reset(new API::Interface(Actions(), Control(), Debug(), Observation(), Query()));
     m_plugins.reserve(10);
 
@@ -91,9 +92,11 @@ void Dispatcher::OnStep() {
     gHub->OnStep();
 
     for (const auto& i : m_plugins)
-        i->OnStep(m_builder.get());
+        if (i->CheckFrequency(m_steps))
+            i->OnStep(m_builder.get());
 
     m_builder->OnStep();
+    m_steps++;
 }
 
 void Dispatcher::OnUnitCreated(const sc2::Unit* unit_) {

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -42,4 +42,6 @@ struct Dispatcher: sc2::Agent {
     std::shared_ptr<Builder> m_builder;
 
     std::vector<std::shared_ptr<Plugin>> m_plugins;
+
+    uint32_t m_steps;
 };

--- a/src/plugins/Miner.cpp
+++ b/src/plugins/Miner.cpp
@@ -138,6 +138,9 @@ void DistrubuteMineralWorker(const sc2::Unit* unit_) {
 
 }  // namespace
 
+Miner::Miner(): Plugin(7) {
+}
+
 void Miner::OnStep(Builder* builder_) {
     SecureMineralsIncome(builder_);
     SecureVespeneIncome();
@@ -151,7 +154,12 @@ void Miner::OnUnitCreated(const sc2::Unit* unit_, Builder*) {
         DistrubuteMineralWorker(unit_);
 }
 
-void Miner::OnUnitIdle(const sc2::Unit* unit_, Builder*) {
+void Miner::OnUnitIdle(const sc2::Unit* unit_, Builder* builder_) {
     if (unit_->unit_type == gHub->GetCurrentWorkerType())
         DistrubuteMineralWorker(unit_);
+
+    if (sc2::IsTownHall()(unit_->unit_type) &&
+        unit_->assigned_harvesters <= unit_->ideal_harvesters &&
+        builder_->CountScheduledOrders(gHub->GetCurrentWorkerType()) < 1)
+        builder_->ScheduleOptionalOrder(gHub->GetCurrentWorkerType(), unit_);
 }

--- a/src/plugins/Miner.h
+++ b/src/plugins/Miner.h
@@ -8,6 +8,8 @@
 #include "Plugin.h"
 
 struct Miner : Plugin {
+    Miner();
+
     void OnStep(Builder* builder_) final;
 
     void OnUnitCreated(const sc2::Unit* unit_, Builder*) final;

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -1,0 +1,18 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2021 Alexander Kurbatov
+
+#include "Plugin.h"
+
+Plugin::Plugin(): m_frequency(1) {
+}
+
+Plugin::Plugin(uint32_t frequency): m_frequency(frequency) {
+}
+
+bool Plugin::CheckFrequency(uint32_t count_) const {
+    if (count_ % m_frequency == 0)
+        return true;
+
+    return false;
+}

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -9,6 +9,10 @@
 #include <sc2api/sc2_unit.h>
 
 struct Plugin {
+    Plugin();
+
+    explicit Plugin(uint32_t gameloop_frequency);
+
     virtual ~Plugin() {
     }
 
@@ -38,4 +42,9 @@ struct Plugin {
 
     virtual void OnGameEnd() {
     }
+
+    virtual bool CheckFrequency(uint32_t count_) const;
+
+ private:
+    const uint32_t m_frequency;
 };


### PR DESCRIPTION
If gas oversaturated, remove from busy_workers and call DistributeWorker.
If gas under-saturated and any base is mineral-oversaturated, send one of those mineral workers to that gas.

I think this can be accepted separately from Repair and AttackScout?