### PR TITLE
feat: Attack first worker-scout, #16

### DIFF
--- a/src/objects/Worker.cpp
+++ b/src/objects/Worker.cpp
@@ -37,3 +37,8 @@ void Worker::Repair(const sc2::Unit& target_) {
     gAPI->action().ToggleAutocast(Tag(), sc2::ABILITY_ID::EFFECT_REPAIR_SCV);
     m_job = Job::REPAIRING;
 }
+
+void Worker::Attack(const sc2::Unit& target_) {
+    gAPI->action().Cast(ToUnit(), sc2::ABILITY_ID::SMART, target_);
+    m_job = Job::ATTACKING;
+}

--- a/src/objects/Worker.h
+++ b/src/objects/Worker.h
@@ -13,6 +13,7 @@ enum Job {
     BUILDING = 2,
     BUILDING_REFINERY = 3,
     REPAIRING = 4,
+    ATTACKING = 5,
 };
 
 struct Worker: GameObject {
@@ -23,6 +24,8 @@ struct Worker: GameObject {
     void Build(Order* order_, const sc2::Point2D& point_);
 
     void GatherVespene(const sc2::Unit& target_);
+
+    void Attack(const sc2::Unit& target_);
 
     void Repair(const sc2::Unit& target_);
 

--- a/src/strategies/Strategy.cpp
+++ b/src/strategies/Strategy.cpp
@@ -4,6 +4,7 @@
 
 #include "Historican.h"
 #include "Strategy.h"
+#include "Hub.h"
 #include "core/API.h"
 #include "core/Helpers.h"
 
@@ -46,4 +47,22 @@ void Strategy::OnUnitCreated(const sc2::Unit* unit_, Builder*) {
         " added to attack group" << std::endl;
 
     m_units.push_back(unit_);
+}
+
+void Strategy::OnUnitEnterVision(const sc2::Unit* unit_, Builder*) {
+    if (IsCombatUnit()(*unit_))
+        return;
+
+    if (m_attackFirstScout) {
+        AssignWorkerAttack(*unit_);
+        m_attackFirstScout = false;  // only attack first scout, first time seen
+    }
+}
+
+void Strategy::AssignWorkerAttack(const sc2::Unit& target_) {
+    Worker* worker = gHub->GetClosestFreeWorker(target_.pos);
+    if (!worker)
+        return;
+
+    worker->Attack(target_);
 }

--- a/src/strategies/Strategy.h
+++ b/src/strategies/Strategy.h
@@ -13,7 +13,12 @@ struct Strategy : Plugin {
 
     void OnUnitCreated(const sc2::Unit* unit_, Builder*) override;
 
+    void OnUnitEnterVision(const sc2::Unit* unit_, Builder*) override;
+
+    void AssignWorkerAttack(const sc2::Unit& target_);
+
  protected:
+    bool m_attackFirstScout = true;
     float m_attack_limit;
     sc2::Units m_units;
 };


### PR DESCRIPTION
Preemptively attack early scout-worker.
Partly satisfies "Retaliate to early scout's (worker's) attack", but does not wait until attacked.